### PR TITLE
Italian translation

### DIFF
--- a/translate/battery/it.po
+++ b/translate/battery/it.po
@@ -1,7 +1,7 @@
 # Nothing Devices and Battery - Translation Template
 # Translators:
-#
-# SPDX-FileCopyrightText: 2026 Gianpaolo <pingurussi@gmail.com>
+# 2026 Gianpaolo <pingurussi@gmail.com>
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: plasma_applet_com.jaxparrow07.nothingkdewidgets.battery 1."
@@ -11,7 +11,7 @@ msgstr ""
 "POT-Creation-Date: 2026-02-13 00:58+0530\n"
 "PO-Revision-Date: 2026-04-15 18:59+0200\n"
 "Last-Translator: Gianpaolo <pingurussi@gmail.com>\n"
-"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language-Team: Italian\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/translate/battery/it.po
+++ b/translate/battery/it.po
@@ -1,0 +1,114 @@
+# Nothing Devices and Battery - Translation Template
+# Translators:
+#
+# SPDX-FileCopyrightText: 2026 Gianpaolo <pingurussi@gmail.com>
+msgid ""
+msgstr ""
+"Project-Id-Version: plasma_applet_com.jaxparrow07.nothingkdewidgets.battery 1."
+"1\n"
+"Report-Msgid-Bugs-To: https://github.com/jaxparrow07/nothing-kde-widgets/issue"
+"s\n"
+"POT-Creation-Date: 2026-02-13 00:58+0530\n"
+"PO-Revision-Date: 2026-04-15 18:59+0200\n"
+"Last-Translator: Gianpaolo <pingurussi@gmail.com>\n"
+"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language: it_IT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 25.12.3\n"
+
+#: packages/battery/contents/config/config.qml:6
+msgid "General"
+msgstr "Generale"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:41
+msgid "Theme"
+msgstr "Tema"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:46
+msgid "Theme:"
+msgstr "Tema:"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:47
+msgid "Dark"
+msgstr "Scuro"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:47
+msgid "Light"
+msgstr "Chiaro"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:47
+msgid "Follow System"
+msgstr "Segui Sistema"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:53
+msgid "Basic Settings"
+msgstr "Impostazioni Basilari"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:58
+msgid "Device Type:"
+msgstr "Tipo di Dispositivo"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:62
+msgid "Laptop"
+msgstr "Laptop"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:63
+msgid "Desktop PC"
+msgstr "PC Desktop"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:78
+msgid "Update Interval (ms):"
+msgstr "Intervallo Aggiornamento (ms):"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:88
+msgid "Custom Device Icons"
+msgstr "Icone Dispositivo Personalizzate"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:93
+msgid "Icon Mappings:"
+msgstr "Mappature Icone"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:98
+msgid "Add custom icon mappings based on device name patterns"
+msgstr ""
+"Aggiungi mappature di icone personalizzate basate sui pattern del nome del dis"
+"positivo"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:120
+msgid "Device name pattern"
+msgstr "Pattern del nome del dispositivo"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:192
+msgid "Add Mapping"
+msgstr "Aggiungi mappatura"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:206
+msgid "Device History"
+msgstr "Cronologia Dispositivo"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:211
+msgid "Previously Connected:"
+msgstr "Precedentemente connessi:"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:215
+msgid "Bluetooth devices that have been connected to this system"
+msgstr "Dispositivi Bluetooth che sono stati connessi a questo sistema"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:250
+msgid "Quick Add"
+msgstr "Aggiunta veloce"
+
+#: packages/battery/contents/ui/config/ConfigGeneral.qml:266
+msgid "No devices found in history"
+msgstr "Nessun dispositivo trovato nella cronologia"
+
+#: packages/battery/contents/ui/main.qml:673
+msgid "PC"
+msgstr "PC"
+
+#: packages/battery/contents/ui/main.qml:710
+msgid "Detecting Battery..."
+msgstr "Rilevamento Batteria..."

--- a/translate/clock-analog/it.po
+++ b/translate/clock-analog/it.po
@@ -1,8 +1,8 @@
 # Nothing Analog Clock - Translation Template
 # This file is put in the public domain.
 # Translators:
-#
-# SPDX-FileCopyrightText: 2026 Gianpaolo <pingurussi@gmail.com>
+# 2026 Gianpaolo <pingurussi@gmail.com>
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: plasma_applet_com.jaxparrow07.nothingkdewidgets.analogcloc"
@@ -12,7 +12,7 @@ msgstr ""
 "POT-Creation-Date: 2026-02-13 00:57+0530\n"
 "PO-Revision-Date: 2026-04-15 18:53+0200\n"
 "Last-Translator: Gianpaolo <pingurussi@gmail.com>\n"
-"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language-Team: Italian\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/translate/clock-analog/it.po
+++ b/translate/clock-analog/it.po
@@ -1,0 +1,83 @@
+# Nothing Analog Clock - Translation Template
+# This file is put in the public domain.
+# Translators:
+#
+# SPDX-FileCopyrightText: 2026 Gianpaolo <pingurussi@gmail.com>
+msgid ""
+msgstr ""
+"Project-Id-Version: plasma_applet_com.jaxparrow07.nothingkdewidgets.analogcloc"
+"k 2.0\n"
+"Report-Msgid-Bugs-To: https://github.com/jaxparrow07/nothing-kde-widgets/issue"
+"s\n"
+"POT-Creation-Date: 2026-02-13 00:57+0530\n"
+"PO-Revision-Date: 2026-04-15 18:53+0200\n"
+"Last-Translator: Gianpaolo <pingurussi@gmail.com>\n"
+"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language: it_IT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 25.12.3\n"
+
+#: packages/clock-analog/contents/config/config.qml:6
+msgid "Appearance"
+msgstr "Apparenza"
+
+#: packages/clock-analog/contents/ui/config/ConfigAppearance.qml:19
+msgid "Style:"
+msgstr "Stile:"
+
+#: packages/clock-analog/contents/ui/config/ConfigAppearance.qml:52
+#: packages/clock-analog/contents/ui/VariantSelector.qml:34
+msgid "Swiss Railway"
+msgstr "Ferrovie Federali Svizzere"
+
+#: packages/clock-analog/contents/ui/config/ConfigAppearance.qml:88
+#: packages/clock-analog/contents/ui/VariantSelector.qml:35
+msgid "Minimalist"
+msgstr "Minimalista"
+
+#: packages/clock-analog/contents/ui/config/ConfigAppearance.qml:112
+msgid "Smooth Moving Second Hand"
+msgstr "Lancetta Secondi Fluida"
+
+#: packages/clock-analog/contents/ui/config/ConfigAppearance.qml:117
+msgid ""
+"Update second hand every 50ms instead of 1000ms ( 1s ) for a smoother motion"
+msgstr ""
+"Aggiorna la lancetta dei secondi ogni 50 ms invece di ogni 1000 ms ( 1s ) per "
+"ottenere un movimento più fluido"
+
+#: packages/clock-analog/contents/ui/config/ConfigAppearance.qml:134
+msgid "Theme:"
+msgstr "Tema:"
+
+#: packages/clock-analog/contents/ui/config/ConfigAppearance.qml:140
+msgid "Dark"
+msgstr "Scuro"
+
+#: packages/clock-analog/contents/ui/config/ConfigAppearance.qml:140
+msgid "Light"
+msgstr "Chiaro"
+
+#: packages/clock-analog/contents/ui/config/ConfigAppearance.qml:140
+msgid "Follow System"
+msgstr "Segui Sistema"
+
+#: packages/clock-analog/contents/ui/config/ConfigAppearance.qml:146
+msgid ""
+"Dark: Nothing's signature dark aesthetic. Light: Nothing's light palette. "
+"Follow System: Uses your KDE color scheme."
+msgstr ""
+"Scuro: l’inconfondibile estetica scura di Nothing. Chiaro: la palette chiara d"
+"i Nothing."
+"Segui Sistema: usa lo schema colori di KDE."
+
+#: packages/clock-analog/contents/ui/VariantSelector.qml:24
+msgid "Choose Style"
+msgstr "Scegli Stile"
+
+#: packages/clock-analog/contents/ui/VariantSelector.qml:61
+msgid "can be changed later in configuration"
+msgstr "Può essere cambiato dopo nella configurazione"

--- a/translate/clock-digital-large/it.po
+++ b/translate/clock-digital-large/it.po
@@ -1,0 +1,132 @@
+# Nothing Digital Clock Large - Translation Template
+# This file is put in the public domain.
+# Translators:
+#
+# SPDX-FileCopyrightText: 2026 Gianpaolo <pingurussi@gmail.com>
+msgid ""
+msgstr ""
+"Project-Id-Version: plasma_applet_com.jaxparrow07.nothingkdewidgets.digitalclo"
+"cklarge 1.1\n"
+"Report-Msgid-Bugs-To: https://github.com/jaxparrow07/nothing-kde-widgets/issue"
+"s\n"
+"POT-Creation-Date: 2026-02-13 00:57+0530\n"
+"PO-Revision-Date: 2026-04-15 19:39+0200\n"
+"Last-Translator: Gianpaolo <pingurussi@gmail.com>\n"
+"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language: it_IT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 25.12.3\n"
+
+#: packages/clock-digital-large/contents/config/config.qml:6
+msgid "Appearance"
+msgstr "Apparenza"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:20
+msgid "Font Style:"
+msgstr "Stile Font:"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:26
+msgid "Dotted"
+msgstr "Punteggiato"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:26
+msgid "Dot Matrix"
+msgstr "Matrice di punti"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:26
+msgid "Serif"
+msgstr "Serif"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:26
+msgid "Segmented"
+msgstr "Segmentato"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:26
+msgid "Segmented Sharp"
+msgstr "Segmentato con bordi netti"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:32
+msgid "Dotted: Bigger dots, cleaner look"
+msgstr "Punteggiato: punti più grandi, aspetto più pulito."
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:40
+msgid "Dot Matrix: Nothing's iconic dot matrix font"
+msgstr "Matrice di punti: l’iconico carattere a matrice di punti di Nothing."
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:48
+msgid "Serif: Nothing's new serif font"
+msgstr "Serif: il nuovo font di Nothing."
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:56
+msgid "Segmented: Subway board inspired font that nothing designed"
+msgstr ""
+"Segmentato: carattere ispirato ai tabelloni della metropolitana, progettato da"
+" Nothing."
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:64
+msgid "Segmented Sharp: Segmented but sharper"
+msgstr ""
+"Segmentato con bordi netti: versione del carattere segmentato con contorni più"
+" netti."
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:72
+msgid "NOTE: Segmented fonts don't have separator (:)"
+msgstr "NOTA: I font segmentati non hanno i separatori (:)"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:90
+msgid "Show Date"
+msgstr "Mostra Data"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:95
+msgid "Display the current date above the time (e.g., \"Thu, 31 Jan\")"
+msgstr "Mostra la data corrente sopra l’ora (es. “Gio, 31 Gen”)."
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:105
+msgid "Use 24-Hour Format"
+msgstr "Usa il formato a 24 ore"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:110
+msgid ""
+"Show time in 24-hour format (e.g., 14:30) instead of 12-hour format (e.g., "
+"2:30)"
+msgstr ""
+"Mostra il tempo in un formato a 24 ore (es. 14:30) invece del formato 12 ore "
+" (es. 2:30)"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:127
+msgid "Use Darker Font Color"
+msgstr "Usa un colore del testo più scuro"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:132
+msgid "Use a darker font color for better visibility on lighter backgrounds"
+msgstr ""
+"Usa un colore del testo più scuro per una migliore leggibilità su sfondi chiar"
+"i"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:148
+msgid "Theme:"
+msgstr "Tema:"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:154
+msgid "Dark"
+msgstr "Scuro"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:154
+msgid "Light"
+msgstr "Chiaro"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:154
+msgid "Follow System"
+msgstr "Segui Sistema"
+
+#: packages/clock-digital-large/contents/ui/config/ConfigAppearance.qml:160
+msgid ""
+"Dark: Nothing's signature dark aesthetic. Light: Nothing's light palette. "
+"Follow System: Uses your KDE color scheme."
+msgstr ""
+"Scuro: l’inconfondibile estetica scura di Nothing. Chiaro: la palette chiara d"
+"i Nothing."
+"Segui Sistema: usa lo schema colori di KDE."

--- a/translate/clock-digital-large/it.po
+++ b/translate/clock-digital-large/it.po
@@ -1,8 +1,8 @@
 # Nothing Digital Clock Large - Translation Template
 # This file is put in the public domain.
 # Translators:
-#
-# SPDX-FileCopyrightText: 2026 Gianpaolo <pingurussi@gmail.com>
+# 2026 Gianpaolo <pingurussi@gmail.com>
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: plasma_applet_com.jaxparrow07.nothingkdewidgets.digitalclo"
@@ -12,7 +12,7 @@ msgstr ""
 "POT-Creation-Date: 2026-02-13 00:57+0530\n"
 "PO-Revision-Date: 2026-04-15 19:39+0200\n"
 "Last-Translator: Gianpaolo <pingurussi@gmail.com>\n"
-"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language-Team: Italian\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/translate/clock-digital/it.po
+++ b/translate/clock-digital/it.po
@@ -1,0 +1,113 @@
+# Nothing Digital Clock - Translation Template
+# This file is put in the public domain.
+# Translators:
+#
+# SPDX-FileCopyrightText: 2026 Gianpaolo <pingurussi@gmail.com>
+msgid ""
+msgstr ""
+"Project-Id-Version: plasma_applet_com.jaxparrow07.nothingkdewidgets.digitalclo"
+"ck 2.0\n"
+"Report-Msgid-Bugs-To: https://github.com/jaxparrow07/nothing-kde-widgets/issue"
+"s\n"
+"POT-Creation-Date: 2026-02-13 00:57+0530\n"
+"PO-Revision-Date: 2026-04-15 19:32+0200\n"
+"Last-Translator: Gianpaolo <pingurussi@gmail.com>\n"
+"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language: it_IT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 25.12.3\n"
+
+#: packages/clock-digital/contents/config/config.qml:6
+msgid "General"
+msgstr "Generale"
+
+#: packages/clock-digital/contents/ui/config/ConfigGeneral.qml:72
+msgid "Style:"
+msgstr "Stile:"
+
+#: packages/clock-digital/contents/ui/config/ConfigGeneral.qml:105
+#: packages/clock-digital/contents/ui/VariantSelector.qml:34
+msgid "Digital Clock"
+msgstr "Orologio Digitale"
+
+#: packages/clock-digital/contents/ui/config/ConfigGeneral.qml:141
+#: packages/clock-digital/contents/ui/VariantSelector.qml:35
+msgid "World Clock"
+msgstr "Orologio Mondiale"
+
+#: packages/clock-digital/contents/ui/config/ConfigGeneral.qml:166
+msgid "Use 24-Hour Format"
+msgstr "Usa il formato a 24 ore"
+
+#: packages/clock-digital/contents/ui/config/ConfigGeneral.qml:172
+msgid ""
+"Show time in 24-hour format (e.g., 14:30) instead of 12-hour format (e.g., "
+"2:30)"
+msgstr ""
+"Mostra il tempo in un formato a 24 ore (es. 14:30) invece del formato a 12 ore"
+" (es. "
+"2:30)"
+
+#: packages/clock-digital/contents/ui/config/ConfigGeneral.qml:190
+msgid "City Name:"
+msgstr "Nome Città:"
+
+#: packages/clock-digital/contents/ui/config/ConfigGeneral.qml:196
+msgid "e.g., Austin, New York, Tokyo"
+msgstr "es., Austin, New York, Tokyo"
+
+#: packages/clock-digital/contents/ui/config/ConfigGeneral.qml:202
+msgid "Enter the city name to display on the widget."
+msgstr "Inserisci il nome della città da mostrare nel widget."
+
+#: packages/clock-digital/contents/ui/config/ConfigGeneral.qml:219
+msgid "Time Zone:"
+msgstr "Fuso Orario:"
+
+#: packages/clock-digital/contents/ui/config/ConfigGeneral.qml:244
+msgid ""
+"Select a timezone from the list above. The widget will display the time for "
+"the selected location."
+msgstr ""
+"Seleziona un fuso orario dall’elenco sopra. Il widget mostrerà l’ora della "
+"località selezionata."
+
+#: packages/clock-digital/contents/ui/config/ConfigGeneral.qml:262
+msgid "Theme:"
+msgstr "Tema:"
+
+#: packages/clock-digital/contents/ui/config/ConfigGeneral.qml:268
+msgid "Dark"
+msgstr "Scuro"
+
+#: packages/clock-digital/contents/ui/config/ConfigGeneral.qml:268
+msgid "Light"
+msgstr "Chiaro"
+
+#: packages/clock-digital/contents/ui/config/ConfigGeneral.qml:268
+msgid "Follow System"
+msgstr "Segui Sistema"
+
+#: packages/clock-digital/contents/ui/config/ConfigGeneral.qml:274
+msgid ""
+"Dark: Nothing's signature dark aesthetic. Light: Nothing's light palette. "
+"Follow System: Uses your KDE color scheme."
+msgstr ""
+"Scuro: L’estetica scura tipica di Nothing. Chiaro: La palette chiara di Nothin"
+"g."
+"Segui Sistema: Segue lo schema chiaro/scuro di KDE."
+
+#: packages/clock-digital/contents/ui/main.qml:269
+msgid "click to configure"
+msgstr "clicca per configurare"
+
+#: packages/clock-digital/contents/ui/VariantSelector.qml:24
+msgid "Choose Style"
+msgstr "Scegli Stile"
+
+#: packages/clock-digital/contents/ui/VariantSelector.qml:61
+msgid "can be changed later in configuration"
+msgstr "Può essere cambiato dopo nella configurazione"

--- a/translate/clock-digital/it.po
+++ b/translate/clock-digital/it.po
@@ -1,8 +1,8 @@
 # Nothing Digital Clock - Translation Template
 # This file is put in the public domain.
 # Translators:
-#
-# SPDX-FileCopyrightText: 2026 Gianpaolo <pingurussi@gmail.com>
+# 2026 Gianpaolo <pingurussi@gmail.com>
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: plasma_applet_com.jaxparrow07.nothingkdewidgets.digitalclo"
@@ -12,7 +12,7 @@ msgstr ""
 "POT-Creation-Date: 2026-02-13 00:57+0530\n"
 "PO-Revision-Date: 2026-04-15 19:32+0200\n"
 "Last-Translator: Gianpaolo <pingurussi@gmail.com>\n"
-"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language-Team: Italian\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/translate/date/it.po
+++ b/translate/date/it.po
@@ -1,8 +1,8 @@
 # Nothing Date - Translation Template
 # This file is put in the public domain.
 # Translators:
-#
-# SPDX-FileCopyrightText: 2026 Gianpaolo <pingurussi@gmail.com>
+# 2026 Gianpaolo <pingurussi@gmail.com>
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: plasma_applet_com.jaxparrow07.nothingkdewidgets.date 1.1\n"
@@ -11,7 +11,7 @@ msgstr ""
 "POT-Creation-Date: 2026-02-13 00:57+0530\n"
 "PO-Revision-Date: 2026-04-15 18:21+0200\n"
 "Last-Translator: Gianpaolo <pingurussi@gmail.com>\n"
-"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language-Team: Italian\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/translate/date/it.po
+++ b/translate/date/it.po
@@ -1,0 +1,49 @@
+# Nothing Date - Translation Template
+# This file is put in the public domain.
+# Translators:
+#
+# SPDX-FileCopyrightText: 2026 Gianpaolo <pingurussi@gmail.com>
+msgid ""
+msgstr ""
+"Project-Id-Version: plasma_applet_com.jaxparrow07.nothingkdewidgets.date 1.1\n"
+"Report-Msgid-Bugs-To: https://github.com/jaxparrow07/nothing-kde-widgets/issue"
+"s\n"
+"POT-Creation-Date: 2026-02-13 00:57+0530\n"
+"PO-Revision-Date: 2026-04-15 18:21+0200\n"
+"Last-Translator: Gianpaolo <pingurussi@gmail.com>\n"
+"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language: it_IT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 25.12.3\n"
+
+#: packages/date/contents/config/config.qml:6
+msgid "General"
+msgstr "Generale"
+
+#: packages/date/contents/ui/config/ConfigGeneral.qml:16
+msgid "Theme:"
+msgstr "Tema:"
+
+#: packages/date/contents/ui/config/ConfigGeneral.qml:22
+msgid "Dark"
+msgstr "Scuro"
+
+#: packages/date/contents/ui/config/ConfigGeneral.qml:22
+msgid "Light"
+msgstr "Chiaro"
+
+#: packages/date/contents/ui/config/ConfigGeneral.qml:22
+msgid "Follow System"
+msgstr "Segui Sistema"
+
+#: packages/date/contents/ui/config/ConfigGeneral.qml:28
+msgid ""
+"Dark: Nothing's signature dark aesthetic. Light: Nothing's light palette. "
+"Follow System: Uses your KDE color scheme."
+msgstr ""
+"Scuro: l’inconfondibile estetica scura di Nothing."
+"Chiaro: la palette chiara di Nothing."
+"Segui Sistema: usa lo schema colori di KDE."

--- a/translate/media/it.po
+++ b/translate/media/it.po
@@ -1,8 +1,8 @@
 # Nothing Media - Translation Template
 # This file is put in the public domain.
 # Translators:
-#
-# SPDX-FileCopyrightText: 2026 Gianpaolo <pingurussi@gmail.com>
+# 2026 Gianpaolo <pingurussi@gmail.com>
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: plasma_applet_com.jaxparrow07.nothingkdewidgets.media 1.1"
@@ -12,7 +12,7 @@ msgstr ""
 "POT-Creation-Date: 2026-02-13 00:57+0530\n"
 "PO-Revision-Date: 2026-04-15 19:28+0200\n"
 "Last-Translator: Gianpaolo <pingurussi@gmail.com>\n"
-"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language-Team: Italian\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/translate/media/it.po
+++ b/translate/media/it.po
@@ -1,0 +1,50 @@
+# Nothing Media - Translation Template
+# This file is put in the public domain.
+# Translators:
+#
+# SPDX-FileCopyrightText: 2026 Gianpaolo <pingurussi@gmail.com>
+msgid ""
+msgstr ""
+"Project-Id-Version: plasma_applet_com.jaxparrow07.nothingkdewidgets.media 1.1"
+"\n"
+"Report-Msgid-Bugs-To: https://github.com/jaxparrow07/nothing-kde-widgets/issue"
+"s\n"
+"POT-Creation-Date: 2026-02-13 00:57+0530\n"
+"PO-Revision-Date: 2026-04-15 19:28+0200\n"
+"Last-Translator: Gianpaolo <pingurussi@gmail.com>\n"
+"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language: it_IT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 25.12.3\n"
+
+#: packages/media/contents/config/config.qml:6
+msgid "General"
+msgstr "Generale"
+
+#: packages/media/contents/ui/config/ConfigGeneral.qml:16
+msgid "Theme:"
+msgstr "Tema:"
+
+#: packages/media/contents/ui/config/ConfigGeneral.qml:22
+msgid "Dark"
+msgstr "Scuro"
+
+#: packages/media/contents/ui/config/ConfigGeneral.qml:22
+msgid "Light"
+msgstr "Chiaro"
+
+#: packages/media/contents/ui/config/ConfigGeneral.qml:22
+msgid "Follow System"
+msgstr "Segui Sistema"
+
+#: packages/media/contents/ui/config/ConfigGeneral.qml:28
+msgid ""
+"Dark: Nothing's signature dark aesthetic. Light: Nothing's light palette. "
+"Follow System: Uses your KDE color scheme."
+msgstr ""
+"Scuro: L’estetica scura tipica di Nothing. Chiaro: La palette chiara di Nothin"
+"g."
+"Segui Sistema: Segue lo schema chiaro/scuro di KDE."

--- a/translate/photo/it.po
+++ b/translate/photo/it.po
@@ -1,0 +1,175 @@
+# Nothing Photo - Translation Template
+# This file is put in the public domain.
+# Translators:
+#
+# SPDX-FileCopyrightText: 2026 Gianpaolo <pingurussi@gmail.com>
+msgid ""
+msgstr ""
+"Project-Id-Version: plasma_applet_com.jaxparrow07.nothingkdewidgets.photo 1.1"
+"\n"
+"Report-Msgid-Bugs-To: https://github.com/jaxparrow07/nothing-kde-widgets/issue"
+"s\n"
+"POT-Creation-Date: 2026-02-13 00:57+0530\n"
+"PO-Revision-Date: 2026-04-15 19:43+0200\n"
+"Last-Translator: Gianpaolo <pingurussi@gmail.com>\n"
+"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language: it_IT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 25.12.3\n"
+
+#: packages/photo/contents/config/config.qml:6
+msgid "Image"
+msgstr "Immagine"
+
+#: packages/photo/contents/config/config.qml:11
+msgid "Appearance"
+msgstr "Apparenza"
+
+#: packages/photo/contents/ui/config/ConfigAppearance.qml:19
+msgid "Border Settings"
+msgstr "Impostazione dei Bordi"
+
+#: packages/photo/contents/ui/config/ConfigAppearance.qml:27
+msgid "Enable Borders"
+msgstr "Abilita Bordi"
+
+#: packages/photo/contents/ui/config/ConfigAppearance.qml:32
+msgid ""
+"Adds margin around the image to reveal the dark background, creating a frame "
+"effect"
+msgstr ""
+"Aggiunge un margine attorno all’immagine, facendo emergere lo sfondo scuro e c"
+"reando un "
+"effetto cornice."
+
+#: packages/photo/contents/ui/config/ConfigAppearance.qml:45
+msgid "Border Size:"
+msgstr "Dimensione Bordo:"
+
+#: packages/photo/contents/ui/config/ConfigAppearance.qml:73
+msgid "Shape Settings"
+msgstr "Impostazioni Forma"
+
+#: packages/photo/contents/ui/config/ConfigAppearance.qml:81
+msgid "Pill Shape"
+msgstr "Forma a Pillola"
+
+#: packages/photo/contents/ui/config/ConfigAppearance.qml:86
+msgid ""
+"Automatically creates a circle (if square) or pill shape (if rectangular). "
+"When disabled, uses standard rounded corners."
+msgstr ""
+"Crea automaticamente un cerchio (se l’immagine è quadrata) oppure una forma a "
+"pillola (se è rettangolare). Quando è disattivato, utilizza i normali angoli a"
+"rrotondati."
+
+#: packages/photo/contents/ui/config/ConfigAppearance.qml:102
+msgid "Theme"
+msgstr "Tema"
+
+#: packages/photo/contents/ui/config/ConfigAppearance.qml:109
+msgid "Theme:"
+msgstr "Tema:"
+
+#: packages/photo/contents/ui/config/ConfigAppearance.qml:115
+msgid "Dark"
+msgstr "Scuro"
+
+#: packages/photo/contents/ui/config/ConfigAppearance.qml:115
+msgid "Light"
+msgstr "Chiaro"
+
+#: packages/photo/contents/ui/config/ConfigAppearance.qml:115
+msgid "Follow System"
+msgstr "Segui Sistema"
+
+#: packages/photo/contents/ui/config/ConfigAppearance.qml:121
+msgid ""
+"Dark: Nothing's signature dark aesthetic. Light: Nothing's light palette. "
+"Follow System: Uses your KDE color scheme."
+msgstr ""
+"Scuro: l’estetica scura tipica di Nothing. Chiaro: La palette chiara di Nothin"
+"g. "
+"Segui Sistema: Segue lo schema chiaro/scuro di KDE."
+
+#: packages/photo/contents/ui/config/ConfigImage.qml:19
+msgid "Image Source"
+msgstr "Sorgente Immagine"
+
+#: packages/photo/contents/ui/config/ConfigImage.qml:31
+msgid "Select an image file..."
+msgstr "Seleziona un file immagine..."
+
+#: packages/photo/contents/ui/config/ConfigImage.qml:36
+msgid "Browse..."
+msgstr "Sfoglia..."
+
+#: packages/photo/contents/ui/config/ConfigImage.qml:42
+msgid "Select a photo to display in the widget (PNG, JPG, JPEG, WebP)"
+msgstr "Seleziona una foto da mostrare nel widget (PNG, JPG, JPEG, WebP)"
+
+#: packages/photo/contents/ui/config/ConfigImage.qml:58
+msgid "Image Fit Mode"
+msgstr "Modalità di adattamento dell’immagine"
+
+#: packages/photo/contents/ui/config/ConfigImage.qml:68
+msgid "Fit Mode:"
+msgstr "Modalità di adattamento dell’immagine:"
+
+#: packages/photo/contents/ui/config/ConfigImage.qml:74
+msgid "Crop (Fill Frame)"
+msgstr "Ritaglia (Riempi Cornice)"
+
+#: packages/photo/contents/ui/config/ConfigImage.qml:74
+msgid "Fit (Show All)"
+msgstr "Adatta (mostra tutto)"
+
+#: packages/photo/contents/ui/config/ConfigImage.qml:74
+msgid "Stretch"
+msgstr "Estendi"
+
+#: packages/photo/contents/ui/config/ConfigImage.qml:80
+msgid ""
+"Crop: Fills the frame completely, may crop parts of the image\n"
+"Fit: Shows the entire image, may have letterboxing\n"
+"Stretch: Fills frame completely, may distort the image"
+msgstr ""
+"Ritaglia: riempie completamente la cornice, può tagliare parti dell’immagine."
+"\n"
+"Adatta: mostra l’intera immagine, possono comparire barre laterali.\n"
+"Estendi: riempie completamente la cornice, può deformare l’immagine."
+
+#: packages/photo/contents/ui/config/ConfigImage.qml:96
+msgid "Effects"
+msgstr "Effetti"
+
+#: packages/photo/contents/ui/config/ConfigImage.qml:104
+msgid "Grayscale"
+msgstr "Toni di grigi"
+
+#: packages/photo/contents/ui/config/ConfigImage.qml:109
+msgid "Convert the image to black and white (grayscale)"
+msgstr "Converte l’immagine in bianco e nero (toni di grigi)."
+
+#: packages/photo/contents/ui/config/ConfigImage.qml:123
+msgid "Select an Image"
+msgstr "Seleziona un'immagine"
+
+#: packages/photo/contents/ui/main.qml:184
+msgid "No Image"
+msgstr "Nessuna immagine"
+
+#: packages/photo/contents/ui/main.qml:193
+msgid "Right-click to configure"
+msgstr "Tasto destro per configurare"
+
+#: packages/photo/contents/ui/main.qml:225
+msgid "Image Error"
+msgstr "Errore Immagine"
+
+#: packages/photo/contents/ui/main.qml:234
+msgid "Failed to load image"
+msgstr "Caricamento dell'immagine fallito"

--- a/translate/photo/it.po
+++ b/translate/photo/it.po
@@ -1,8 +1,8 @@
 # Nothing Photo - Translation Template
 # This file is put in the public domain.
 # Translators:
-#
-# SPDX-FileCopyrightText: 2026 Gianpaolo <pingurussi@gmail.com>
+# 2026 Gianpaolo <pingurussi@gmail.com>
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: plasma_applet_com.jaxparrow07.nothingkdewidgets.photo 1.1"
@@ -12,7 +12,7 @@ msgstr ""
 "POT-Creation-Date: 2026-02-13 00:57+0530\n"
 "PO-Revision-Date: 2026-04-15 19:43+0200\n"
 "Last-Translator: Gianpaolo <pingurussi@gmail.com>\n"
-"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language-Team: Italian\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/translate/weather/it.po
+++ b/translate/weather/it.po
@@ -1,0 +1,278 @@
+# Nothing Weather - Translation Template
+# This file is put in the public domain.
+# Translators:
+# SPDX-FileCopyrightText: 2026 Gianpaolo <pingurussi@gmail.com>
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: plasma_applet_com.jaxparrow07.nothingkdewidgets.weather 2."
+"0\n"
+"Report-Msgid-Bugs-To: https://github.com/jaxparrow07/nothing-kde-widgets/issue"
+"s\n"
+"POT-Creation-Date: 2026-04-10 17:06+0000\n"
+"PO-Revision-Date: 2026-04-15 19:28+0200\n"
+"Last-Translator: Gianpaolo <pingurussi@gmail.com>\n"
+"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language: it_IT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Lokalize 25.12.3\n"
+
+#: packages/weather/contents/ui/VariantSelector.qml:24
+#, fuzzy
+msgid "Choose Style"
+msgstr "Scegli Stile"
+
+#: packages/weather/contents/ui/VariantSelector.qml:34
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:54
+msgid "Full"
+msgstr "Completo"
+
+#: packages/weather/contents/ui/VariantSelector.qml:35
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:90
+msgid "Circular"
+msgstr "Circolare"
+
+#: packages/weather/contents/ui/VariantSelector.qml:36
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:126
+msgid "Circle Pages"
+msgstr "Pagine Circolari"
+
+#: packages/weather/contents/ui/VariantSelector.qml:62
+msgid "can be changed later in configuration"
+msgstr "Può essere cambiato dopo nella configurazione"
+
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:21
+msgid "Style:"
+msgstr "Stile:"
+
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:149
+msgid "Location:"
+msgstr "Località:"
+
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:155
+msgid "e.g., Victoria, Canada or New York, US"
+msgstr "es., Victoria, Canada o New York, US"
+
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:161
+msgid ""
+"Enter a city name, optionally followed by a country (e.g., 'Victoria, "
+"Canada'). The widget will automatically find the coordinates."
+msgstr ""
+"Inserisci il nome di una città, seguito opzionalmente da un paese (es. ‘Victor"
+"ia, "
+"Canada’). Il widget troverà automaticamente le coordinate."
+
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:178
+msgid "Temperature Unit:"
+msgstr "Unità di temperatura:"
+
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:184
+msgid "Celsius (°C)"
+msgstr "Celsius (°C)"
+
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:184
+msgid "Fahrenheit (°F)"
+msgstr "Fahrenheit (°F)"
+
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:190
+msgid "Choose between Celsius and Fahrenheit for temperature display."
+msgstr ""
+"Scegli tra Celsius e Fahrenheit per la visualizzazione della temperatura."
+
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:207
+msgid "Theme:"
+msgstr "Tema:"
+
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:213
+msgid "Dark"
+msgstr "Scuro"
+
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:213
+msgid "Light"
+msgstr "Chiaro"
+
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:213
+msgid "Follow System"
+msgstr "Segui sistema"
+
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:219
+msgid ""
+"Dark: Nothing's signature dark aesthetic. Light: Nothing's light palette. "
+"Follow System: Matches your KDE dark/light scheme."
+msgstr ""
+"Scuro: L’estetica scura tipica di Nothing. Chiaro: La palette chiara di Nothin"
+"g."
+"Segui Sistema: Segue lo schema chiaro/scuro di KDE."
+
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:229
+msgid "Use system accent color"
+msgstr "Usa il colore di accento del sistema"
+
+#: packages/weather/contents/ui/config/ConfigGeneral.qml:234
+msgid ""
+"Replace Nothing's red accent with your KDE system highlight color while "
+"keeping the Nothing aesthetic."
+msgstr ""
+"Sostituisci il rosso di Nothing con il colore di evidenziazione del sistema KD"
+"E"
+"mantenendo l’estetica di Nothing."
+
+#: packages/weather/contents/ui/main.qml:36
+msgid "Loading..."
+msgstr "Caricamento..."
+
+#: packages/weather/contents/ui/main.qml:114
+msgid "Clear"
+msgstr "Sereno"
+
+#: packages/weather/contents/ui/main.qml:115
+msgid "Mainly Clear"
+msgstr "Prevalentemente Sereno"
+
+#: packages/weather/contents/ui/main.qml:116
+msgid "Partly Cloudy"
+msgstr "Parzialmente Nuvoloso"
+
+#: packages/weather/contents/ui/main.qml:117
+msgid "Overcast"
+msgstr "Coperto"
+
+#: packages/weather/contents/ui/main.qml:118
+msgid "Fog"
+msgstr "Nebbia"
+
+#: packages/weather/contents/ui/main.qml:119
+msgid "Depositing Rime Fog"
+msgstr "Galaverna"
+
+#: packages/weather/contents/ui/main.qml:120
+msgid "Light Drizzle"
+msgstr "Pioviggine Leggera"
+
+#: packages/weather/contents/ui/main.qml:121
+msgid "Drizzle"
+msgstr "Pioviggine"
+
+#: packages/weather/contents/ui/main.qml:122
+msgid "Dense Drizzle"
+msgstr "Pioviggine Fitta"
+
+#: packages/weather/contents/ui/main.qml:123
+msgid "Light Freezing Drizzle"
+msgstr "Pioviggine Gelata Leggera"
+
+#: packages/weather/contents/ui/main.qml:124
+msgid "Freezing Drizzle"
+msgstr "Pioviggine Gelata"
+
+#: packages/weather/contents/ui/main.qml:125
+msgid "Slight Rain"
+msgstr "Pioggia Leggera"
+
+#: packages/weather/contents/ui/main.qml:126
+msgid "Rain"
+msgstr "Pioggia"
+
+#: packages/weather/contents/ui/main.qml:127
+msgid "Heavy Rain"
+msgstr "Pioggia Forte"
+
+#: packages/weather/contents/ui/main.qml:128
+msgid "Light Freezing Rain"
+msgstr "Pioggia Gelata Debole"
+
+#: packages/weather/contents/ui/main.qml:129
+msgid "Freezing Rain"
+msgstr "Pioggia Gelata"
+
+#: packages/weather/contents/ui/main.qml:130
+msgid "Slight Snow"
+msgstr "Neve Debole"
+
+#: packages/weather/contents/ui/main.qml:131
+msgid "Snow"
+msgstr "Neve"
+
+#: packages/weather/contents/ui/main.qml:132
+msgid "Heavy Snow"
+msgstr "Neve Forte"
+
+#: packages/weather/contents/ui/main.qml:133
+msgid "Snow Grains"
+msgstr "Granuli di Neve"
+
+#: packages/weather/contents/ui/main.qml:134
+msgid "Slight Rain Showers"
+msgstr "Rovesci di Pioggia Deboli"
+
+#: packages/weather/contents/ui/main.qml:135
+msgid "Rain Showers"
+msgstr "Rovesci di Pioggia"
+
+#: packages/weather/contents/ui/main.qml:136
+msgid "Violent Rain Showers"
+msgstr "Rovesci di Pioggia Intensi"
+
+#: packages/weather/contents/ui/main.qml:137
+msgid "Slight Snow Showers"
+msgstr "Rovesci di Neve Deboli"
+
+#: packages/weather/contents/ui/main.qml:138
+msgid "Heavy Snow Showers"
+msgstr "Rovesci di Neve Forti"
+
+#: packages/weather/contents/ui/main.qml:139
+msgid "Thunderstorm"
+msgstr "Tempesta"
+
+#: packages/weather/contents/ui/main.qml:140
+msgid "Thunderstorm with Hail"
+msgstr "Temporale con grandine"
+
+#: packages/weather/contents/ui/main.qml:141
+msgid "Heavy Thunderstorm with Hail"
+msgstr "Forte Temporale con Grandine"
+
+#: packages/weather/contents/ui/main.qml:142
+msgid "Unknown"
+msgstr "Sconosciuto"
+
+#: packages/weather/contents/ui/main.qml:149
+msgid "SUN"
+msgstr "DOM"
+
+#: packages/weather/contents/ui/main.qml:149
+msgid "MON"
+msgstr "LUN"
+
+#: packages/weather/contents/ui/main.qml:149
+msgid "TUE"
+msgstr "MAR"
+
+#: packages/weather/contents/ui/main.qml:149
+msgid "WED"
+msgstr "MER"
+
+#: packages/weather/contents/ui/main.qml:149
+msgid "THU"
+msgstr "GIO"
+
+#: packages/weather/contents/ui/main.qml:149
+msgid "FRI"
+msgstr "VEN"
+
+#: packages/weather/contents/ui/main.qml:149
+msgid "SAT"
+msgstr "SAB"
+
+#: packages/weather/contents/ui/main.qml:285
+#: packages/weather/contents/ui/main.qml:288
+msgid "Location not found"
+msgstr "Posizione non trovata"
+
+#: packages/weather/contents/config/config.qml:6
+msgid "General"
+msgstr "Generale"

--- a/translate/weather/it.po
+++ b/translate/weather/it.po
@@ -1,8 +1,8 @@
 # Nothing Weather - Translation Template
 # This file is put in the public domain.
 # Translators:
-# SPDX-FileCopyrightText: 2026 Gianpaolo <pingurussi@gmail.com>
-#
+# 2026 Gianpaolo <pingurussi@gmail.com>
+#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: plasma_applet_com.jaxparrow07.nothingkdewidgets.weather 2."
@@ -12,7 +12,7 @@ msgstr ""
 "POT-Creation-Date: 2026-04-10 17:06+0000\n"
 "PO-Revision-Date: 2026-04-15 19:28+0200\n"
 "Last-Translator: Gianpaolo <pingurussi@gmail.com>\n"
-"Language-Team: Italian <kde-i18n-it@kde.org>\n"
+"Language-Team: Italian\n"
 "Language: it_IT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"


### PR DESCRIPTION
Italian translation of all strings

NOTE: I'm not sure if this is a problem i introduced or a problem in the project, but the translation for

**msgid ""
"Dark: Nothing's signature dark aesthetic. Light: Nothing's light palette. "
"Follow System: Matches your KDE dark/light scheme."**

only seems to work in the weather plasmoid, every other widget ignores the translation strings and uses the english one