### PR TITLE
Support coordinate-based weather locations

### DIFF
--- a/packages/weather/contents/ui/config/ConfigGeneral.qml
+++ b/packages/weather/contents/ui/config/ConfigGeneral.qml
@@ -152,13 +152,13 @@ KCM.SimpleKCM {
 
             TextField {
                 id: locationField
-                placeholderText: i18n("e.g., Victoria, Canada or New York, US")
+                placeholderText: i18n("e.g., Victoria, Canada or Home|48.4284,-123.3656")
                 Layout.fillWidth: true
             }
         }
 
         Label {
-            text: i18n("Enter a city name, optionally followed by a country (e.g., 'Victoria, Canada'). The widget will automatically find the coordinates.")
+            text: i18n("Enter a city name, optionally followed by a country (e.g., 'Victoria, Canada'). For ambiguous or hard-to-find places, enter exact coordinates as 'Label|latitude,longitude'.")
             font.pointSize: 9
             opacity: 0.7
             Layout.fillWidth: true

--- a/packages/weather/contents/ui/main.qml
+++ b/packages/weather/contents/ui/main.qml
@@ -28,6 +28,7 @@ PlasmoidItem {
     // Configuration properties
     property string location: plasmoid.configuration.location
     property int temperatureUnit: plasmoid.configuration.temperatureUnit
+    readonly property string displayLocation: location.indexOf("|") >= 0 ? location.split("|")[0].trim() : location
 
     // WEATHER DATA
     property string currentTemp: "--"
@@ -258,10 +259,38 @@ PlasmoidItem {
         return results[0]
     }
 
+    function parseConfiguredCoordinates() {
+        var value = location
+        if (value.indexOf("|") >= 0)
+            value = value.split("|").slice(1).join("|")
+
+        var match = value.match(/^\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*$/)
+        if (!match)
+            return null
+
+        var lat = Number(match[1])
+        var lon = Number(match[2])
+        if (isNaN(lat) || isNaN(lon) || lat < -90 || lat > 90 || lon < -180 || lon > 180)
+            return null
+
+        return {
+            latitude: lat,
+            longitude: lon
+        }
+    }
+
     // Geocoding function
     function geocodeLocation() {
         isLoading = true
         errorMessage = ""
+
+        var configuredCoordinates = parseConfiguredCoordinates()
+        if (configuredCoordinates) {
+            latitude = configuredCoordinates.latitude
+            longitude = configuredCoordinates.longitude
+            fetchWeatherData()
+            return
+        }
 
         var parts = location.split(",").map(function(s) { return s.trim() })
         var city = parts[0]
@@ -528,7 +557,7 @@ PlasmoidItem {
                         weatherIconPath: root.weatherIconPath
                         isLoading: root.isLoading
                         errorMessage: root.errorMessage
-                        location: root.location
+                        location: root.displayLocation
                     }
 
                     SquarePageTwo {
@@ -563,7 +592,7 @@ PlasmoidItem {
                         currentTemp: root.currentTemp
                         highTemp: root.highTemp
                         lowTemp: root.lowTemp
-                        location: root.location
+                        location: root.displayLocation
                         condition: root.condition
                     }
 


### PR DESCRIPTION
## Summary

Add support for coordinate-based weather locations in the Weather widget, with an optional display label.

The location field now accepts:

- `City, Country` as before, using Open-Meteo geocoding
- `latitude,longitude` to bypass geocoding
- `Label|latitude,longitude` to bypass geocoding while keeping a readable label in the widget

## Problem

Some locations are ambiguous or hard to find through Open-Meteo's text geocoding alone. When multiple places share the same city name, the API can return a different result before the user's intended location. In other cases, a more specific local place name may not be returned by text search at all.

The widget already depends on Open-Meteo coordinates for weather data, so allowing users to provide exact coordinates is a reliable fallback for these cases.

## Changes

- Parse `Label|latitude,longitude` and `latitude,longitude` before calling the geocoding API.
- Validate coordinate ranges before using them.
- Preserve the existing city-name geocoding path for current users.
- Display only the label portion when the `Label|latitude,longitude` format is used.
- Update the configuration hint text with the new coordinate format.

## Testing

- Ran `qmllint` on the modified QML files.
- Ran `git diff --check`.
- Generated AppStream metadata for `packages/weather` with `kpackagetool6 --appstream-metainfo`.

No private local paths, tokens, or user-specific coordinates are included in this change.
