### PR TITLE
fix(media): use mipmap for album artwork

### DIFF
--- a/packages/media/contents/ui/components/AlbumArtwork.qml
+++ b/packages/media/contents/ui/components/AlbumArtwork.qml
@@ -22,6 +22,7 @@ Item {
         source: artworkRoot.artUrl
         fillMode: Image.PreserveAspectCrop
         smooth: true
+        mipmap: true
         visible: false
         layer.enabled: true
     }

--- a/packages/media/contents/ui/components/CompactPlayer.qml
+++ b/packages/media/contents/ui/components/CompactPlayer.qml
@@ -61,6 +61,7 @@ Item {
                             anchors.fill: parent
                             source: compactRoot.albumArt
                             fillMode: Image.PreserveAspectCrop
+                            mipmap: true
                             smooth: true
                             visible: compactRoot.albumArt !== ""
                         }


### PR DESCRIPTION
The previous design passed only `smooth: true`, but that's not enough for such small scale.
This PR improves album-art rendering quality by enabling `mipmap` when covers are scaled down.

- Enable mipmap filtering for the main album artwork.
- Enable the same filtering for the compact-player thumbnail.
- Preserve the existing aspect-crop and smoothing behavior.
