### PR TITLE
feat(media): rounded corners for compact view album artwork

### DIFF
--- a/packages/media/contents/ui/components/CompactPlayer.qml
+++ b/packages/media/contents/ui/components/CompactPlayer.qml
@@ -54,26 +54,13 @@ Item {
                         Layout.preferredHeight: 80
                         color: compactRoot.colors.surface
                         radius: 12
-                        clip: true
 
-                        Image {
-                            id: thumbnailImage
+                        AlbumArtwork {
                             anchors.fill: parent
-                            source: compactRoot.albumArt
-                            fillMode: Image.PreserveAspectCrop
-                            mipmap: true
-                            smooth: true
-                            visible: compactRoot.albumArt !== ""
-                        }
-
-                        // Fallback icon
-                        Kirigami.Icon {
-                            anchors.centerIn: parent
-                            width: 48
-                            height: 48
-                            source: "media-optical-audio"
-                            color: compactRoot.colors.textDisabled
-                            visible: compactRoot.albumArt === ""
+                            colors: compactRoot.colors
+                            artUrl: compactRoot.albumArt
+                            cornerRadius: 12
+                            backgroundColor: compactRoot.colors.surface
                         }
                     }
 


### PR DESCRIPTION
Apply the existing `AlbumArtwork` component to the Compact View thumbnail.

- Use the same rounded-corner mask as the main artwork.
- Reuse its mipmap filtering and missing-artwork fallback.
- Remove the ineffective rectangular clipping and duplicate thumbnail rendering code.

<img width="190" height="191" alt="image" src="https://github.com/user-attachments/assets/36455c48-feb2-41e1-9d0f-4ef41a328360" />
